### PR TITLE
会員登録処理完了、管理側ドロップダウン修正、顧客側注文ページの保護

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -9,6 +9,7 @@ use Illuminate\Http\Request;
 use Illuminate\Foundation\Auth\RegistersUsers;
 use App\Http\Requests\RegisterRequest;
 use Illuminate\Auth\Events\Registered;
+use Laracasts\Flash\Flash;
 
 class RegisterController extends Controller
 {
@@ -77,7 +78,7 @@ class RegisterController extends Controller
             'phone' => $data['phone'],
             'gender_id' => $data['gender_id'],
             'birthday' => $data['birthday'],
-            'authority_id' => $data['authority_id'],
+            'authority_id' => 3,
 
         ]);
     }
@@ -88,24 +89,18 @@ class RegisterController extends Controller
     return view('auth.register.confirm',compact('data'));
     }
 
-    public function getregister()
+    public function register()
     {
     $prefs = config('pref');
     
     return view('auth.register')->with(['prefs' => $prefs]);
     }
     
-    public function register(Request $request)
+    public function complete(Request $request)
     {
-        $this->validator($request->all())->validate();
+        $data = $request->all();
 
-        event(new Registered($user = $this->create($request->all())));
-
-        return view('register/complete');
-    }
-
-    public function complete()
-    {
-        return view('auth.register.complete');
+        event(new Registered($user = $this->create($data)));
+       return view('auth.register.complete');
     }
 }

--- a/app/Http/Requests/RegisterRequest.php
+++ b/app/Http/Requests/RegisterRequest.php
@@ -13,7 +13,7 @@ class RegisterRequest extends FormRequest
      */
     public function authorize()
     {
-        return false;
+        return true;
     }
 
     /**
@@ -24,7 +24,6 @@ class RegisterRequest extends FormRequest
     public function rules()
     {
         return [
-            //
             'name' => 'required|max:50',
             'name_katakana' => 'required|max:100',
             'postal' => 'required|size:7|string',

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -25,7 +25,6 @@ katakana : true  //true：カタカナ、false：ひらがな（デフォルト�
     <h1 class="text-center title">新規会員登録</h1>
 </div>
 <div class="row">
-    <div class="col-md-12">
         <form role="form" method="POST" action="{{ url('/register/confirm') }}">
         {{ csrf_field() }}
     <font class="red">※</font>の項目は必ず入力してください
@@ -37,13 +36,8 @@ katakana : true  //true：カタカナ、false：ひらがな（デフォルト�
                     <label for="name">氏名<font class="red">※</font></label>
                 </th>
                     <td class="form-inline">
-                      <input id="name" type="text" class="form-control" name="name" value="{{ old('name') }}" required autofocus>
+                      <input id="name" type="text" class="form-control" name="name" value="{{ old('name') }}">
                       <span class="example">例)情報太郎</span>
-                         @if ($errors->has('name'))
-                               <span class="help-block">
-                                    <strong>{{ $errors->first('name') }}</strong>
-                               </span>
-                         @endif
                     </td>
               </div>
         </tr>
@@ -53,13 +47,8 @@ katakana : true  //true：カタカナ、false：ひらがな（デフォルト�
                     <label for="kana">カナ<font class="red">※</font></label>
                 </th>
                     <td class="form-inline">
-                      <input id="kana" type="text" class="form-control" name="kana" value="{{ old('name') }}"  required autofocus>
+                      <input id="kana" type="text" class="form-control" name="kana" value="{{ old('name') }}">
                       <span class="example">例)ジョウホウタロウ</span>
-                         @if ($errors->has('kana'))
-                               <span class="help-block">
-                                    <strong>{{ $errors->first('kana') }}</strong>
-                               </span>
-                         @endif
                     </td>
               </div>
         </tr>
@@ -69,13 +58,8 @@ katakana : true  //true：カタカナ、false：ひらがな（デフォルト�
                     <label for="email">Eメールアドレス<font class="red">※</font></label>
                 </th>
                     <td class="form-inline">
-                       <input id="email" type="email" class="form-control" name="email" value="{{ old('email') }}" required>
+                       <input id="email" type="email" class="form-control" name="email" value="{{ old('email') }}">
                        <span class="example">例)oic@example.com</span>
-                         @if ($errors->has('email'))
-                                <span class="help-block">
-                                    <strong>{{ $errors->first('email') }}</strong>
-                                </span>
-                         @endif
                     </td>
               </div>
         </tr>
@@ -85,13 +69,8 @@ katakana : true  //true：カタカナ、false：ひらがな（デフォルト�
                     <label for="password">パスワード<font class="red">※</font></label>
                 </th>
                     <td class="form-inline">
-                       <input id="password" type="password" class="form-control" name="password" required>
+                       <input id="password" type="password" class="form-control" name="password">
                        <span class="example">数字とアルファベット大文字を一文字ずつ、6文字以上入力してください。</span>
-                          @if ($errors->has('password'))
-                                <span class="help-block">
-                                    <strong>{{ $errors->first('password') }}</strong>
-                                </span>
-                          @endif
                     </td>
              </div>
         </tr>
@@ -101,13 +80,9 @@ katakana : true  //true：カタカナ、false：ひらがな（デフォルト�
                     <label for="password-confirm">確認パスワード<font class="red">※</font></label>
                 </th>
                     <td class="form-inline">
-                        <input id="password-confirm" type="password" class="form-control" name="password_confirmation" required>
+                        <input id="password-confirm" type="password" class="form-control" name="password_confirmation">
                         <span class="example">確認の為、もう一度入力してください。</span>
-                           @if ($errors->has('password_confirmation'))
-                                 <span class="help-block">
-                                    <strong>{{ $errors->first('password_confirmation') }}</strong>
-                                 </span>
-                           @endif
+
                      </td>
               </div>
         </tr>
@@ -177,7 +152,7 @@ katakana : true  //true：カタカナ、false：ひらがな（デフォルト�
                             <label for="phone">電話番号<font class="red">※</font></label>
                         </th>
                             <td class="form-inline">
-                                <input id="phone" type="text" class="form-control" name="phone" onKeyup="this.value=this.value.replace(/[^0-9]+/i,'')" maxlength="11" value="{{ old('phone') }}" required>
+                                <input id="phone" type="text" class="form-control" name="phone" onKeyup="this.value=this.value.replace(/[^0-9]+/i,'')" maxlength="11" value="{{ old('phone') }}">
                                 <span class="example">例)0663400017　のようにハイフンを付けずに入力してください。</span>
                             </td>
                       </div>
@@ -199,17 +174,13 @@ katakana : true  //true：カタカナ、false：ひらがな（デフォルト�
                                   <label for="birthday">誕生日<font class="red">※</font></label>
                               </th>
                                 <td class="form-inline">
-                                   <input type="date" class="form-control" name="birthday" value="{{ old('birthday') }}" required>
+                                   <input type="date" class="form-control" name="birthday" value="{{ old('birthday') }}">
                                    <span class="example">西暦で入力してください</span>
                                 </td>
                            </div>
                        </tr>
                 </tbody>
          </table>
-         
-         <div class="form-group{{ $errors->has('authority_id') ? ' has-error' : '' }}">
-              <input type="hidden" name="authority_id" value="3">
-         </div>
               <div class="text-center">
                    <button type="submit" class="btn btn-primary">次へ</button>
               </div>

--- a/resources/views/auth/register/confirm.blade.php
+++ b/resources/views/auth/register/confirm.blade.php
@@ -1,134 +1,131 @@
-@extends('template.auth') @section('title', '新規登録確認') @section('css')
+@extends('template.auth') 
+
+@section('title', '新規登録確認') 
+
+@section('css')
 <link rel="stylesheet" href="/css/pages/index.css" media="all" title="no title">
-<link rel="stylesheet" href="/css/auth/register/index.css" media="all" title="no title"> @endsection @section('js')
+<link rel="stylesheet" href="/css/auth/register/index.css" media="all" title="no title">
+@endsection
+
+@section('js')
 <script type="text/javascript" src="https://ajaxzip3.github.io/ajaxzip3.js" charset="utf-8"></script>
 <script src="/js/common/autokana/jquery.autoKana.js" language="javascript" type="text/javascript"></script>
-@endsection @section('main')
+@endsection 
+
+@section('main')
 <div class="container">
   <div class="text-center">
     <h1>新規会員登録確認</h1>
   </div>
     <div class="row">
-             <form role="form" method="POST" action="{{ url('/register/complete') }}">
-             {{ csrf_field() }}
-             <p>下記の内容で通りに登録します。</p>
-                    
-        <table class="table table-responsive">
-            <tbody>
-                <tr>
-                    <div class="form-group{{ $errors->has('name') ? ' has-error' : '' }}">
-                    <th><label for="name">氏名<font style="red">※</font></label></th>
-                        <td class="form-inline">
-    <div class="text-center">
-        <h1 style="">新規会員登録確認</h1>
-    </div>
-    <div class="row">
-        <div class="col-md-9 col-md-offset-1">
-            <div class="">
-                <div class="">
-                    <form class="" role="form" method="POST" action="{{ url('/register/complete') }}">
+                    <form role="form" method="POST" action="{{ url('/register/complete') }}">
                         {{ csrf_field() }}
-                        <div class="">
-                            下記の内容で通りに登録します。<br>
-                        </div>
-                        <table class="table regist_table regist_confirm">
-
+                        <table class="table table-responcive">
+                         <tbody>
                           <tr>
                         <div class="form-group{{ $errors->has('name') ? ' has-error' : '' }}">
-                          <th>
-                            <label for="name" class="">氏名<font color="#FF0000">※</font></label>
-                            </th>
-                            <td>
-                            <div class="col-md-4">
+                        <th><label for="name">氏名<font class="red">※</font></label></th>
+                        <td class="form-inline">
                               <h4>{{ $data['name'] }}</h4>
+                              <input type="hidden" class="form-control" name="name" value="{{ $data['name'] }}">
                         </td>
                    </div>
                </tr>
                <tr>
                     <div class="form-group{{ $errors->has('kana') ? ' has-error' : '' }}">
-                    <th><label for="kana" class="">カナ<font style="red">※</font></label></th>
+                    <th><label for="kana">カナ<font class="red">※</font></label></th>
                         <td class="form-inline">
                               <h4>{{ $data['kana'] }}</h4>
+                              <input type="hidden" class="form-control" name="kana" value="{{ $data['kana'] }}">
                         </td>
                    </div>
                </tr>
                <tr>
                     <div class="form-group{{ $errors->has('email') ? ' has-error' : '' }}">
-                    <th><label for="email" class="">Eメールアドレス<font style="red">※</font></label></th>
+                    <th><label for="email">Eメールアドレス<font class="red">※</font></label></th>
                         <td class="form-inline">
                               <h4>{{ $data['email'] }}</h4>
+                              <input type="hidden" class="form-control" name="email" value="{{ $data['email'] }}">
                         </td>
                    </div>
                </tr>
                <tr>
-                    <th><label for="postal" class="control-label">郵便番号 (半角)<font style="red">※</font></label></th>
+                    <th><label for="postal" class="control-label">郵便番号 (半角)<font class="red">※</font></label></th>
                     <td class="form-inline">
                               <h4>{{ $data['postal'] }}</h4>
+                              <input type="hidden" class="form-control" name="postal" value="{{ $data['postal'] }}">
                     </td>
                </tr>
                <tr>
                     <div class="form-group{{ $errors->has('pref') ? ' has-error' : '' }}">
-                    <th><label for="pref" class="">都道府県<font style="red">※</font></label></th>
+                    <th><label for="pref">都道府県<font class="red">※</font></label></th>
                         <td class="form-inline">
                         
                               <h4>{{ $data['pref'] }}</h4>
+                              <input type="hidden" class="form-control" name="pref" value="{{ $data['pref'] }}">
                         </td>
                    </div>
                </tr>
                <tr>
                     <div class="form-group{{ $errors->has('address1') ? ' has-error' : '' }}">
-                    <th><label for="address1" class="">市区町村 (全角)<font style="red">※</font></label></th>
+                    <th><label for="address1">市区町村 (全角)<font class="red">※</font></label></th>
                         <td class="form-inline">
                               <h4>{{ $data['address1'] }}</h4>
+                              <input type="hidden" class="form-control" name="address1" value="{{ $data['address1'] }}">
                         </td>
                    </div>
                </tr>
                <tr>
                     <div class="form-group{{ $errors->has('address2') ? ' has-error' : '' }}">
-                    <th><label for="address2" class="">町名・番地 (全角)<font style="red">※</font></label></th>
+                    <th><label for="address2">町名・番地 (全角)<font class="red">※</font></label></th>
                         <td class="form-inline">
                               <h4>{{ $data['address2'] }}</h4>
+                              <input type="hidden" class="form-control" name="address2" value="{{ $data['address2'] }}">
                         </td>
                    </div>
                </tr>
                <tr>
                     <div class="form-group{{ $errors->has('address2') ? ' has-error' : '' }}">
-                    <th><label for="address3" class="">建物名 (全角)</label></th>
+                    <th><label for="address3">建物名 (全角)</label></th>
                         <td class="form-inline">
                               <h4>{{ $data['address3'] }}</h4>
+                              <input type="hidden" class="form-control" name="address3" value="{{ $data['address3'] }}">
                         </td>
                    </div>
                </tr>
                <tr>
                     <div class="form-group{{ $errors->has('phone') ? ' has-error' : '' }}">
-                    <th><label for="phone" class="">電話番号<font style="red">※</font></label></th>
+                    <th><label for="phone">電話番号<font class="red">※</font></label></th>
                         <td class="form-inline">
                               <h4>{{ $data['phone'] }}</h4>
+                              <input type="hidden" class="form-control" name="phone" value="{{ $data['phone'] }}">
                         </td>
                    </div>
                </tr>
                <tr>
                     <div class="form-group{{ $errors->has('gender_id') ? ' has-error' : '' }}">
-                    <th><label for="gender_id" class="">性別<font style="red">※</font></label></th>
+                    <th><label for="gender_id">性別<font class="red">※</font></label></th>
                         <td class="form-inline">
                               <h4>{{ $data['gender_id'] }}</h4>
+                              <input type="hidden" class="form-control" name="gender_id" value="{{ $data['gender_id'] }}">
                         </td>
                    </div>
                </tr>
                <tr>
                     <div class="form-group{{ $errors->has('birthday') ? ' has-error' : '' }}">
-                    <th><label for="birthday" class="">誕生日<font style="red">※</font></label></th>
+                    <th><label for="birthday">誕生日<font class="red">※</font></label></th>
                         <td class="form-inline">
                               <h4>{{ $data['birthday'] }}</h4>
+                              <input type="hidden" class="form-control" name="birthday" value="{{ $data['birthday'] }}">
                         </td>
                    </div>
                </tr>
         </tbody>
  </table>
- 
-    <div class="form-group{{ $errors->has('authority_id') ? ' has-error' : '' }}">
-        <input type="hidden" name="authority_id" value="3">
-    </div>
+
+   <div class="form-group{{ $errors->has('password') ? ' has-error' : '' }}">
+    <input type="hidden" class="form-control" name="password" value="{{ $data['password'] }}">
+   </div>
 
     <div class="text-center">
         <button type="submit" class="btn btn-primary">登録</button>
@@ -137,10 +134,3 @@
  </div>
 </div>
 @endsection
-                    </form>
-                    </div>
-                </div>
-            </div>
-        </div>
-    </div>
-    @endsection

--- a/resources/views/template/admin.blade.php
+++ b/resources/views/template/admin.blade.php
@@ -35,8 +35,9 @@
         <div class="collapse navbar-collapse" id="bs-example-navbar-collapse-1">
             <ul class="nav navbar-nav">
                 <li class="dropdown">
-                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">注文確認<span class="caret"></span></a>
+                    <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">注文<span class="caret"></span></a>
                     <ul class="dropdown-menu">
+                        <li><a href="/pizzzzza/order">注文確認</a></li>
                         <li><a href="/pizzzzza/order/history">注文履歴</a></li>
                     </ul>
                 </li>

--- a/routes/web.php
+++ b/routes/web.php
@@ -155,8 +155,7 @@ Route::post('/pizzzzza/order/top', 'auth\AdminLoginController@login'); //管理�
 
 Auth::routes();
 
-Route::post('/register','auth\RegisterController@register'); //登録処理
-Route::get('/register','auth\RegisterController@getregister'); //登録ページ
-Route::post('/register/complete','auth\RegisterController@complete');
+Route::get('/register','auth\RegisterController@register'); //登録ページ
 Route::post('/register/confirm', 'auth\RegisterController@confirm');
+Route::post('/register/complete','auth\RegisterController@complete');
 Route::get('password/input' ,'auth\ResetPasswordController@input'); //パスワードリセットメール入力ページ

--- a/routes/web.php
+++ b/routes/web.php
@@ -25,7 +25,6 @@
     Route::post('/cart/clear', 'CartsController@clear');
 
 //　注文
-    Route::get('/order/confirm', 'OrdersController@index')->name('order');
     Route::post('/order/confirm/insert', 'OrdersController@insert');
     Route::get('/order/complete', 'OrdersController@complete')->name('complete');
     Route::any('/order/confirm/coupon', 'OrdersController@coupon');
@@ -37,6 +36,9 @@
     Route::get('/faq', 'PagesController@faq');
 
 Route::group(['middleware' => ['userauth']], function () {
+
+//注文ページ
+    Route::get('/order/confirm', 'OrdersController@index')->name('order');
 
 //マイページ
     Route::get('/mypage/order/history', 'MypagesController@orderHistory');


### PR DESCRIPTION
会員登録処理完了。(テスト済)
管理側ドロップダウン'注文'に変更し、注文履歴、注文確認のリンクを追加。
ログインしていない状態で商品を追加し、注文ページに進むとログインページに飛ばされるようにページを保護。

・課題
会員登録画面のバリデーション未実装。