### PR TITLE
電話注文::注文確認画面のバグ修正（GETアクセスにも対応）

### DIFF
--- a/app/Http/Controllers/PhoneOrdersController.php
+++ b/app/Http/Controllers/PhoneOrdersController.php
@@ -351,8 +351,17 @@ class PhoneOrdersController extends Controller
         // 会員情報
         $user = $this->phoneOrderService->getUser($id);
 
-        // 商品
-        $data = $this->phoneOrderService->getPrice($request);
+
+        // 商品、個数、金額（POSTアクセス時と、リロードやredirectなどGETでアクセスされた場合の切り分け）
+        if($request->all()) {  // POSTの場合（$requestから値を取得）
+
+            $data = $this->phoneOrderService->getPrice($request);
+
+        }else{  // GETの場合（sessionから値を取得）
+
+            $data = $this->phoneOrderService->getPrice($request);
+
+        }
 
         // 商品一覧
         $items = $data['result'];
@@ -378,8 +387,8 @@ class PhoneOrdersController extends Controller
 
         $appointment_date = $date .' '. $time;
 
-        // もし現在時刻より前だったら
-        if ($appointment_date <= Carbon::now()->format('Y-m-d H:i')) {
+        // もし現在時刻＋１時間より前だったら
+        if ($appointment_date <= Carbon::now()->addHour()->format('Y-m-d H:i')) {
 
             Flash::error('配達希望日時は１時間後より指定可能です。');
             return redirect()->route('telOrderConfirm',$id);

--- a/app/Http/Controllers/PhoneOrdersController.php
+++ b/app/Http/Controllers/PhoneOrdersController.php
@@ -388,7 +388,7 @@ class PhoneOrdersController extends Controller
         $appointment_date = $date .' '. $time;
 
         // もし現在時刻＋１時間より前だったら
-        if ($appointment_date <= Carbon::now()->addHour()->format('Y-m-d H:i')) {
+        if ($appointment_date <= Carbon::now()->addHour()->addMinute()->format('Y-m-d H:i')) {
 
             Flash::error('配達希望日時は１時間後より指定可能です。');
             return redirect()->route('telOrderConfirm',$id);

--- a/app/Service/PhoneOrderService.php
+++ b/app/Service/PhoneOrderService.php
@@ -200,7 +200,12 @@ class PhoneOrderService
 
         $today = Carbon::today();
 
-        $items = $request->all();
+        // POSTならフォームの値を優先し、GETならセッションの値を利用する。
+        if($request->all()) {
+            $items = $request->all();
+        }else{
+            $items = session()->get('phoneOrderCart');
+        }
 
         // 商品名を取得 [0]=> "商品名"、[1]=>"商品名"...
         $keys = array_keys($items);
@@ -235,7 +240,6 @@ class PhoneOrderService
 
         return compact('result','total');
     }
-
 
     /**
      * 注文確定

--- a/resources/views/pizzzzza/menu/show.blade.php
+++ b/resources/views/pizzzzza/menu/show.blade.php
@@ -10,6 +10,8 @@
         <li><a href="/pizzzzza/order">ホーム</a></li>
         @if(preg_match('{history}',$_SERVER["HTTP_REFERER"]))
             <li><a href="/pizzzzza/menu/history">商品履歴</a></li>
+        @elseif(preg_match('{accept}',$_SERVER["HTTP_REFERER"]))
+            <li><a href="{{ url($_SERVER["HTTP_REFERER"]) }}">電話注文:商品選択</a></li>
         @else
             <li><a href="/pizzzzza/menu">商品一覧</a></li>
         @endif
@@ -84,6 +86,8 @@
         <div class="col-md-4 col-md-offset-4 mt">
             @if(preg_match('{history}',$_SERVER["HTTP_REFERER"]))
                 <a href="/pizzzzza/menu/history" class="btn btn-default btn-lg btn-block">戻る</a>
+            @elseif(preg_match('{accept}',$_SERVER["HTTP_REFERER"]))
+                <a href="{{ url($_SERVER["HTTP_REFERER"]) }}" class="btn btn-default btn-lg btn-block">戻る</a>
             @else
                 <a href="/pizzzzza/menu" class="btn btn-default btn-lg btn-block">戻る</a>
             @endif

--- a/resources/views/pizzzzza/menu/show.blade.php
+++ b/resources/views/pizzzzza/menu/show.blade.php
@@ -13,7 +13,6 @@
         @elseif(preg_match('{accept}',$_SERVER["HTTP_REFERER"]))
             <li><a href="/pizzzzza/order/accept/input">電話注文</a></li>
             <li><a href="{{ url($_SERVER["HTTP_REFERER"]) }}">商品選択</a></li>
-            <li class="active">商品詳細</li>
         @else
             <li><a href="/pizzzzza/menu">商品一覧</a></li>
         @endif

--- a/resources/views/pizzzzza/menu/show.blade.php
+++ b/resources/views/pizzzzza/menu/show.blade.php
@@ -11,7 +11,9 @@
         @if(preg_match('{history}',$_SERVER["HTTP_REFERER"]))
             <li><a href="/pizzzzza/menu/history">商品履歴</a></li>
         @elseif(preg_match('{accept}',$_SERVER["HTTP_REFERER"]))
-            <li><a href="{{ url($_SERVER["HTTP_REFERER"]) }}">電話注文:商品選択</a></li>
+            <li><a href="/pizzzzza/order/accept/input">電話注文</a></li>
+            <li><a href="{{ url($_SERVER["HTTP_REFERER"]) }}">商品選択</a></li>
+            <li class="active">商品詳細</li>
         @else
             <li><a href="/pizzzzza/menu">商品一覧</a></li>
         @endif

--- a/resources/views/pizzzzza/order/accept/item/confirm.blade.php
+++ b/resources/views/pizzzzza/order/accept/item/confirm.blade.php
@@ -12,8 +12,8 @@
 <ol class="breadcrumb">
     <li><a href="/pizzzzza/order">ホーム</a></li>
     <li><a href="/pizzzzza/order/accept/input">電話注文</a></li>
-    <li><a href="/pizzzzza/order/accept/customer/{id}/show">お客様情報確認</a></li>
-    <li><a href="/pizzzzza/order/accept/item/{id}/select">商品選択</a></li>
+    <li><a href="/pizzzzza/order/accept/customer/{{ $id }}/show">お客様情報確認</a></li>
+    <li><a href="/pizzzzza/order/accept/item/{{ $id }}/select">商品選択</a></li>
     <li class="active">注文確認</li>
 </ol>
 @endsection


### PR DESCRIPTION
対策済み。

【バグ内容】
　注文確認画面では配達希望日時を指定できるが、現在時刻＋１時間より前の時刻が指定されるとredirectしFlashエラーメッセージを表示する。しかしredirectした際、注文確認画面であるにも関わらずカート内の情報が表示されなかった。

【原因】注文確認画面ではカート内情報を、POSTされたデータより取得していた。

【対策内容】GETアクセス時（redirect時）などでもカート内容が表示できるよう、POSTでない場合はセッションの値を取得する仕様に変更。